### PR TITLE
closed #42 ブロックサークル間移動の経路計算をRコースにも対応させる

### DIFF
--- a/source/block_bingo/block_circles_path.py
+++ b/source/block_bingo/block_circles_path.py
@@ -134,15 +134,15 @@ class BlockCirclesSolver():
         # 原則としてLコースのときは、4番サークルに進入する (Rコースのときは、5番サークル)
         enter = self.coordinate.get(4) if is_left else self.coordinate.get(5)
         # 代替策としてLコースのときは、6版サークルに進入する (Rコースのときは、8番サークル)
-        planB = self.coordinate.get(6) if is_left else self.coordinate.get(8)
+        plan_b = self.coordinate.get(6) if is_left else self.coordinate.get(8)
         
         # 進入サークルにカラーブロックが置いてあるかチェックする
         if enter == self.coordinate.get(self.color):
-            enter = planB
+            enter = plan_b
         
         # 代替策のサークルに黒ブロックが置いてあるかチェックする
-        if planB == self.coordinate.get(self.black):
-            enter = planB
+        if plan_b == self.coordinate.get(self.black):
+            enter = plan_b
         
         return enter
 

--- a/source/block_bingo/block_circles_path.py
+++ b/source/block_bingo/block_circles_path.py
@@ -189,12 +189,28 @@ class BlockCirclesSolver():
         return path
 
 def left_course():
-    solver = BlockCirclesSolver(5, 3, 5)
+    """
+    Lコース版のテストコード
+    """
+    bonus = 5
+    black = 3
+    color = 5
+
+    solver = BlockCirclesSolver(bonus, black, color)
+    # solve関数を呼び出して運搬経路を計算させる(デフォルトでLeftコースの場合になる)
     path = solver.solve()
     print(path)
 
 def right_course():
-    solver = BlockCirclesSolver(4, 8, 6)
+    """
+    Rコース版のテストコード
+    """
+    bonus = 4
+    black = 8
+    color = 6
+
+    solver = BlockCirclesSolver(bonus, black, color)
+    # solve関数を呼び出して運搬経路を計算させる(Rightコースの場合)
     path = solver.solve(False)
     print(path)
 

--- a/source/block_bingo/block_circles_path.py
+++ b/source/block_bingo/block_circles_path.py
@@ -133,7 +133,7 @@ class BlockCirclesSolver():
         """
         # 原則としてLコースのときは、4番サークルに進入する (Rコースのときは、5番サークル)
         enter = self.coordinate.get(4) if is_left else self.coordinate.get(5)
-        # 代替策としてLコースのときは、6版サークルに進入する (Rコースのときは、8番サークル)
+        # 代替策としてLコースのときは、6番サークルに進入する (Rコースのときは、8番サークル)
         plan_b = self.coordinate.get(6) if is_left else self.coordinate.get(8)
         
         # 進入サークルにカラーブロックが置いてあるかチェックする
@@ -213,7 +213,6 @@ def right_course():
     # solve関数を呼び出して運搬経路を計算させる(Rightコースの場合)
     path = solver.solve(False)
     print(path)
-
 class BlockCirclesSolverTest(unittest.TestCase):
     """
     BlockCirclesSolverのテストクラス


### PR DESCRIPTION
タイトル通り、ブロックサークル間移動の経路計算をRコースにも対応させました。

solve関数の引数に `is_left` を加えました。
Rコースの移動経路計算をさせたい場合は、
 1. `solver = BlockCirclesSolver(bonus, black, color)` を作成 (bonus, black, colorはそれぞれサークル番号を入れます)
 2. `solver.solve(False)`
とします。