### PR TITLE
closed #87 ブロックサークル間移動後に黒線へ移動してブロックを設置するコマンドを追加

### DIFF
--- a/source/block_bingo/BlackBlockCommands.py
+++ b/source/block_bingo/BlackBlockCommands.py
@@ -86,7 +86,7 @@ class BlackBlockCommands():
             current_coordinate = self.route[i]
         
         # 黒ブロックを配置するコマンドを追加する
-        commands += Instructions.PUT
+        commands = self.put_to_command(commands)
         return commands
 
     def coordinate_to_command(self, robot_coor, next_coor, direction):
@@ -202,6 +202,21 @@ class BlackBlockCommands():
             return 'l'
         # 回転しない or 180度回転
         return ''
+
+
+    def put_to_command(self, commands):
+        """
+        ブロックサークル間移動後に走行体がブロックを設置するコマンドを追加する。
+        :param commands: ブロックサークル間移動のコマンド
+        """
+        # 末尾のコマンドを削除する
+        commands = commands[:-1]
+        # ブロックサークル間の黒線まで移動するコマンドを追加する
+        commands += Instructions.MOVE_NODE
+        # 黒線からブロックを設置するコマンドを追加する
+        commands += Instructions.PUT
+
+        return commands
 
 
 def main():


### PR DESCRIPTION
### このPRの目的(ISSUEあればURL)
- [BACKコマンドの追加](https://github.com/KatLab-MiyazakiUniv/CameraSystem/issues/87)
- ブロックサークル間移動後の処理を修正するため

### 何をしたか（変更点など）
- ブロックサークル間移動後の処理を変更しました。
- ブロックサークル間を移動したのち、ボーナスサークル手前の黒線へ移動してブロックを設置します。
