### PR TITLE
closed #96 走行体へ送信するコマンドを追加・修正する

### DIFF
--- a/source/block_bingo/BlackBlockCommands.py
+++ b/source/block_bingo/BlackBlockCommands.py
@@ -87,7 +87,7 @@ class BlackBlockCommands():
         
         # 黒ブロックを配置するコマンドを追加する
         commands = self.put_to_command(commands)
-        return commands
+        return commands.replace(Instructions.STRAIGHT * 2, Instructions.STRAIGHT_STRAIGHT)
 
     def coordinate_to_command(self, robot_coor, next_coor, direction):
         """

--- a/source/block_bingo/BlackBlockCommands.py
+++ b/source/block_bingo/BlackBlockCommands.py
@@ -212,7 +212,7 @@ class BlackBlockCommands():
         # 末尾のコマンドを削除する
         commands = commands[:-1]
         # ブロックサークル間の黒線まで移動するコマンドを追加する
-        commands += Instructions.MOVE_NODE
+        commands += Instructions.PREPARE_TO_PUT
         # 黒線からブロックを設置するコマンドを追加する
         commands += Instructions.PUT
 

--- a/source/block_bingo/commands.py
+++ b/source/block_bingo/commands.py
@@ -25,7 +25,7 @@ class Instructions():
     TURN_LEFT90_UNEXIST_BLOCK = 'm'
     TURN180 = 'n'
     PREPARE_TO_PUT = 'o'
-
+    STRAIGHT_STRAIGHT = 'p'
     MOVE_NODE = 'u'
 
     QUICK_PUT_R = 'y'
@@ -49,6 +49,7 @@ class Instructions():
               Instructions.TURN_LEFT90_UNEXIST_BLOCK: '左方向に旋回（ブロックなし）',
               Instructions.TURN180: '180°回頭して直進（ブロックなし）',
               Instructions.PREPARE_TO_PUT: 'ブロックサークルから黒線の中点まで直進',
+              Instructions.STRAIGHT_STRAIGHT: 'ブロックサークル間を2回移動する',
               Instructions.MOVE_NODE: '交点サークル間を移動',
 
               Instructions.QUICK_PUT_R: '交点サークルから右方向に旋回してブロック設置',

--- a/source/block_bingo/commands.py
+++ b/source/block_bingo/commands.py
@@ -23,6 +23,7 @@ class Instructions():
     TURN_LEFT90_EXIST_BLOCK = 'l'
     TURN_LEFT90_UNEXIST_BLOCK = 'm'
     TURN180 = 'n'
+    PREPARE_TO_PUT = 'o'
 
     MOVE_NODE = 'u'
     
@@ -35,7 +36,7 @@ class Instructions():
                 Instructions.ENTER_BINGO_AREA_L6: '6番サークルに進入',
                 Instructions.ENTER_BINGO_AREA_R5: '5番サークルに進入',
                 Instructions.ENTER_BINGO_AREA_R8: '8番サークルに進入',
-                Instructions.STRAIGHT: 'ブロックサークル間を直進',
+                Instructions.STRAIGHT: 'ブロックサークル間を移動',
                 Instructions.SPIN_RIGHT: '右に90°回頭する',
                 Instructions.SPIN_LEFT: '左に90°回頭する',
                 Instructions.SPIN180: '180°回頭する',
@@ -45,9 +46,10 @@ class Instructions():
                 Instructions.TURN_RIGHT90_EXIST_BLOCK: '右方向に旋回（ブロックあり）',
                 Instructions.TURN_LEFT90_EXIST_BLOCK: '左方向に旋回（ブロックあり）',
                 Instructions.TURN_RIGHT90_UNEXIST_BLOCK: '右方向に旋回（ブロックなし）',
-                Instructions.TURN_LEFT90_UNEXIST_BLOCK: '左方向に旋回（ブロックなし）'   ,   
+                Instructions.TURN_LEFT90_UNEXIST_BLOCK: '左方向に旋回（ブロックなし）',
                 Instructions.TURN180: '180°回頭して直進（ブロックなし）',
-                Instructions.MOVE_NODE: '交点サークルから黒線の中点まで直進',
+                Instructions.PREPARE_TO_PUT: 'ブロックサークルから黒線の中点まで直進',
+                Instructions.MOVE_NODE: '交点サークル間を移動',
 
                 Instructions.QUICK_PUT_R: '交点サークルから右方向に旋回してブロック設置',
                 Instructions.QUICK_PUT_L: '交点サークルから左方向に旋回してブロック設置'

--- a/source/block_bingo/commands.py
+++ b/source/block_bingo/commands.py
@@ -102,6 +102,10 @@ class Commands():
     
 
     def get(self):
+        for i in range(1, len(self.commands)):
+            # 連続してMOVE_NODEが続く場合は、1つのMOVE_NODEに変換する
+            if self.commands[i] == Instructions.MOVE_NODE and self.commands[i-1] == Instructions.MOVE_NODE:
+                del self.commands[i-1]
         return self.commands
 
 

--- a/source/block_bingo/commands.py
+++ b/source/block_bingo/commands.py
@@ -6,6 +6,7 @@
 from BlockBingoCoordinate import BlockCirclesCoordinate
 from BlockBingoCoordinate import CrossCirclesCoordinate
 
+
 class Instructions():
     ENTER_BINGO_AREA_L4 = 'a'
     ENTER_BINGO_AREA_L6 = 'b'
@@ -26,34 +27,33 @@ class Instructions():
     PREPARE_TO_PUT = 'o'
 
     MOVE_NODE = 'u'
-    
+
     QUICK_PUT_R = 'y'
     QUICK_PUT_L = 'z'
 
-
     def translate(self, instruction):
-        ja = {  Instructions.ENTER_BINGO_AREA_L4: '4番サークルに進入',
-                Instructions.ENTER_BINGO_AREA_L6: '6番サークルに進入',
-                Instructions.ENTER_BINGO_AREA_R5: '5番サークルに進入',
-                Instructions.ENTER_BINGO_AREA_R8: '8番サークルに進入',
-                Instructions.STRAIGHT: 'ブロックサークル間を移動',
-                Instructions.SPIN_RIGHT: '右に90°回頭する',
-                Instructions.SPIN_LEFT: '左に90°回頭する',
-                Instructions.SPIN180: '180°回頭する',
-                Instructions.PUT: 'ブロックを黒線の中点から設置',
-                Instructions.STRAIGHT_DETOUR_RIGHT: 'ブロックを右方向に迂回しながら直進',
-                Instructions.STRAIGHT_DETOUR_LEFT: 'ブロックを左方向に迂回しながら直進',
-                Instructions.TURN_RIGHT90_EXIST_BLOCK: '右方向に旋回（ブロックあり）',
-                Instructions.TURN_LEFT90_EXIST_BLOCK: '左方向に旋回（ブロックあり）',
-                Instructions.TURN_RIGHT90_UNEXIST_BLOCK: '右方向に旋回（ブロックなし）',
-                Instructions.TURN_LEFT90_UNEXIST_BLOCK: '左方向に旋回（ブロックなし）',
-                Instructions.TURN180: '180°回頭して直進（ブロックなし）',
-                Instructions.PREPARE_TO_PUT: 'ブロックサークルから黒線の中点まで直進',
-                Instructions.MOVE_NODE: '交点サークル間を移動',
+        ja = {Instructions.ENTER_BINGO_AREA_L4: '4番サークルに進入',
+              Instructions.ENTER_BINGO_AREA_L6: '6番サークルに進入',
+              Instructions.ENTER_BINGO_AREA_R5: '5番サークルに進入',
+              Instructions.ENTER_BINGO_AREA_R8: '8番サークルに進入',
+              Instructions.STRAIGHT: 'ブロックサークル間を移動',
+              Instructions.SPIN_RIGHT: '右に90°回頭する',
+              Instructions.SPIN_LEFT: '左に90°回頭する',
+              Instructions.SPIN180: '180°回頭する',
+              Instructions.PUT: 'ブロックを黒線の中点から設置',
+              Instructions.STRAIGHT_DETOUR_RIGHT: 'ブロックを右方向に迂回しながら直進',
+              Instructions.STRAIGHT_DETOUR_LEFT: 'ブロックを左方向に迂回しながら直進',
+              Instructions.TURN_RIGHT90_EXIST_BLOCK: '右方向に旋回（ブロックあり）',
+              Instructions.TURN_LEFT90_EXIST_BLOCK: '左方向に旋回（ブロックあり）',
+              Instructions.TURN_RIGHT90_UNEXIST_BLOCK: '右方向に旋回（ブロックなし）',
+              Instructions.TURN_LEFT90_UNEXIST_BLOCK: '左方向に旋回（ブロックなし）',
+              Instructions.TURN180: '180°回頭して直進（ブロックなし）',
+              Instructions.PREPARE_TO_PUT: 'ブロックサークルから黒線の中点まで直進',
+              Instructions.MOVE_NODE: '交点サークル間を移動',
 
-                Instructions.QUICK_PUT_R: '交点サークルから右方向に旋回してブロック設置',
-                Instructions.QUICK_PUT_L: '交点サークルから左方向に旋回してブロック設置'
-        }
+              Instructions.QUICK_PUT_R: '交点サークルから右方向に旋回してブロック設置',
+              Instructions.QUICK_PUT_L: '交点サークルから左方向に旋回してブロック設置'
+              }
         return ja[instruction]
 
 
@@ -74,8 +74,7 @@ class Commands():
 
         # コマンドのリスト
         self.commands = []
-    
-    
+
     def convert(self, direction, path):
         """
         運搬経路をコマンド変換する。
@@ -99,15 +98,27 @@ class Commands():
                 direction = self.spin(src, dst, direction, has_block)
             direction = self.straight(src, dst, direction, has_block)
         return direction
-    
 
     def get(self):
-        for i in range(1, len(self.commands)):
-            # 連続してMOVE_NODEが続く場合は、1つのMOVE_NODEに変換する
-            if self.commands[i] == Instructions.MOVE_NODE and self.commands[i-1] == Instructions.MOVE_NODE:
-                del self.commands[i-1]
-        return self.commands
+        """
+        変換したコマンドを返す。
+        もし、交点サークル間の移動が2個続いたときは、コマンドを1個にまとめる。
+        2個連続したとき1つにまとめるので、3個連続するときは2個にまとめられる。
+        :return:
+        """
+        commands = list(self.commands[0])
+        needPack = True  # MOVE_NODEを1つにまとめる必要があるかどうかを表す
 
+        for i in range(1, len(self.commands)):
+            # 交点サークル間の移動が2個連続するときは、格納しない
+            if needPack and self.commands[i] == Instructions.MOVE_NODE and \
+                    self.commands[i - 1] == Instructions.MOVE_NODE:
+                # 3個連続したとき1個にまとめられないために、needPackをFalseにする
+                needPack = False
+                continue
+            needPack = True
+            commands.append(self.commands[i])
+        return commands
 
     def get_next_direction(self, src, dst):
         """
@@ -123,18 +134,17 @@ class Commands():
         dst : tuple
             終点の座標
         """
-        subtraction = (dst[0]-src[0], dst[1]-src[1])
+        subtraction = (dst[0] - src[0], dst[1] - src[1])
 
         if subtraction == (-1, 0) or subtraction == (-0.5, 0):
-            return 0    # 北向き
+            return 0  # 北向き
         if subtraction == (0, 1) or subtraction == (0, 0.5):
-            return 2    # 東向き
+            return 2  # 東向き
         if subtraction == (1, 0) or subtraction == (0.5, 0):
-            return 4    # 南向き
+            return 4  # 南向き
         if subtraction == (0, -1) or subtraction == (0, -0.5):
-            return 6    # 西向き
+            return 6  # 西向き
         raise ValueError('could not calculate direction')
-
 
     def spin(self, src, dst, direction, has_block):
         """
@@ -152,7 +162,7 @@ class Commands():
             始点にブロックが存在するか
         """
         next_direction = self.get_next_direction(src, dst)
-        
+
         # 次の方向と現在の方向を引き算する。
         sub = next_direction - direction
         if sub == 0:
@@ -166,9 +176,8 @@ class Commands():
         if sub == -2 or sub == 6:
             self.commands.append(Instructions.SPIN_LEFT)
             return next_direction
-        
+
         raise ArithmeticError('cannot convert path to SPIN command!')
-    
 
     def straight(self, src, dst, direction, has_block):
         """
@@ -194,7 +203,6 @@ class Commands():
             return self.straight_detour(src, dst, direction, has_block)
         self.commands.append(Instructions.MOVE_NODE)
         return direction
-
 
     def turn(self, src, dst, direction, has_block):
         """
@@ -230,7 +238,6 @@ class Commands():
             return next_direction
         raise ArithmeticError('cannot convert path to TURN command!')
 
-
     def turn180(self, src, dst, direction, has_block):
         """
         180°回頭して直進するコマンドへ変換する。
@@ -253,7 +260,6 @@ class Commands():
         self.commands.append(Instructions.TURN180)
 
         return self.get_next_direction(src, dst)
-    
 
     def straight_detour(self, src, dst, direction, has_block):
         """
@@ -268,15 +274,14 @@ class Commands():
             else:
                 self.commands[-1] = Instructions.STRAIGHT_DETOUR_LEFT
             return direction
-        
+
         # 始点が格子状エリアの右端または下端にある場合
         if dst[0] < src[0] or src[1] < dst[1]:
             self.commands[-1] = Instructions.STRAIGHT_DETOUR_LEFT
         else:
             self.commands[-1] = Instructions.STRAIGHT_DETOUR_RIGHT
-        
+
         return direction
-    
 
     def turn_detour(self, src, dst, direction, has_block):
         """
@@ -308,7 +313,6 @@ class Commands():
             return next_direction
         raise ArithmeticError('cannot convert path to TURN command!')
 
-
     def turn180_detour(self, src, dst, direction, has_block):
         """
         ブロックありの180°回頭して直進するコマンドへ変換する。
@@ -333,7 +337,6 @@ class Commands():
         self.commands.append(top)
         # ブロックありの直進コマンドへ変換する
         return self.straight_detour(src, dst, direction, True)
-    
 
     def put(self, src, dst, direction, has_block=False):
         """
@@ -359,7 +362,6 @@ class Commands():
         # 始点が黒線の中点にあるとき
         return self.put_block_from_midpoint(src, dst, direction, has_block)
 
-
     def put_block_from_midpoint(self, src, dst, direction, has_block):
         """
         黒線の中点からブロックを設置する動作をコマンドに変換する。
@@ -378,23 +380,22 @@ class Commands():
         # 黒線の中点の座標からブロックサークルの座標を引く
         sub = (src[0] - dst[0], src[1] - dst[1])
 
-        if sub == (0,0.5): # ブロックサークルの上部の中点
+        if sub == (0, 0.5):  # ブロックサークルの上部の中点
             # 走行体が南に向くように回頭コマンドの変換をする
-            direction = self.spin(src, (src[0]+1, src[1]), direction, has_block)
-        if sub == (0.5,1): # ブロックサークルの左の中点
+            direction = self.spin(src, (src[0] + 1, src[1]), direction, has_block)
+        if sub == (0.5, 1):  # ブロックサークルの左の中点
             # 走行体が西に向くように回頭コマンドの変換をする
-            direction = self.spin(src, (src[0], src[1]-1), direction, has_block)
-        if sub == (1,0.5): # ブロックサークルの下部の中点
+            direction = self.spin(src, (src[0], src[1] - 1), direction, has_block)
+        if sub == (1, 0.5):  # ブロックサークルの下部の中点
             # 走行体が北に向くように回頭コマンドの変換をする
-            direction = self.spin(src, (src[0]-1, src[1]), direction, has_block)
-        if sub == (0.5,0): # ブロックサークルの右の中点
+            direction = self.spin(src, (src[0] - 1, src[1]), direction, has_block)
+        if sub == (0.5, 0):  # ブロックサークルの右の中点
             # 走行体が東に向くように回頭コマンドの変換をする
-            direction = self.spin(src, (src[0], src[1]+1), direction, has_block)
+            direction = self.spin(src, (src[0], src[1] + 1), direction, has_block)
 
         # ブロック設置のコマンド変換をする
         self.commands.append(Instructions.PUT)
-        return direction  
-
+        return direction
 
     def put_block_from_cross_circle(self, src, dst, direction, has_block):
         """
@@ -414,52 +415,52 @@ class Commands():
         # 交点サークルの座標からブロックサークルの座標を引く
         sub = (src[0] - dst[0], src[1] - dst[1])
 
-        if sub == (0,0):    # ブロックサークルの左上の交点サークル
-            if direction == 0 or direction == 2:    # 向きが北 or 東
+        if sub == (0, 0):  # ブロックサークルの左上の交点サークル
+            if direction == 0 or direction == 2:  # 向きが北 or 東
                 # 走行体が東に向くように回頭コマンドの変換をする
-                direction = self.spin(src, (src[0], src[1]+1), direction, has_block)
+                direction = self.spin(src, (src[0], src[1] + 1), direction, has_block)
                 # 右方向にブロックを設置する
                 self.commands.append(Instructions.QUICK_PUT_R)
-            if direction == 4 or direction == 6:    # 向きが西 or 南
+            if direction == 4 or direction == 6:  # 向きが西 or 南
                 # 走行体が南に向くように回頭コマンドの変換をする
-                direction = self.spin(src, (src[0]+1, src[1]), direction, has_block)
+                direction = self.spin(src, (src[0] + 1, src[1]), direction, has_block)
                 # 左方向にブロックを設置する
                 self.commands.append(Instructions.QUICK_PUT_L)
-        
-        if sub == (0,1):    # ブロックサークルの右上の交点サークル
-            if direction == 2 or direction == 4:    # 向きが東 or 南
+
+        if sub == (0, 1):  # ブロックサークルの右上の交点サークル
+            if direction == 2 or direction == 4:  # 向きが東 or 南
                 # 走行体が南に向くように回頭コマンドの変換をする
-                direction = self.spin(src, (src[0]+1, src[1]), direction, has_block)
+                direction = self.spin(src, (src[0] + 1, src[1]), direction, has_block)
                 # 右方向にブロックを設置する
                 self.commands.append(Instructions.QUICK_PUT_R)
-            if direction == 0 or direction == 6:    # 向きが北 or 西
+            if direction == 0 or direction == 6:  # 向きが北 or 西
                 # 走行体が西に向くように回頭コマンドの変換をする
-                direction = self.spin(src, (src[0], src[1]-1), direction, has_block)
+                direction = self.spin(src, (src[0], src[1] - 1), direction, has_block)
                 # 左方向にブロックを設置する
                 self.commands.append(Instructions.QUICK_PUT_L)
-        
-        if sub == (1,0):    # ブロックサークルの左下の交点サークル
-            if direction == 0 or direction == 6:    # 向きが北 or 西
+
+        if sub == (1, 0):  # ブロックサークルの左下の交点サークル
+            if direction == 0 or direction == 6:  # 向きが北 or 西
                 # 走行体が北に向くように回頭コマンドの変換をする
-                direction = self.spin(src, (src[0]-1, src[1]), direction, has_block)
+                direction = self.spin(src, (src[0] - 1, src[1]), direction, has_block)
                 # 右方向にブロックを設置する
                 self.commands.append(Instructions.QUICK_PUT_R)
-            if direction == 2 or direction == 4:    # 向きが東 or 南
+            if direction == 2 or direction == 4:  # 向きが東 or 南
                 # 走行体が東に向くように回頭コマンドの変換をする
-                direction = self.spin(src, (src[0], src[1]+1), direction, has_block)
+                direction = self.spin(src, (src[0], src[1] + 1), direction, has_block)
                 # 左方向にブロックを設置する
                 self.commands.append(Instructions.QUICK_PUT_L)
-        
-        if sub == (1,1):    # ブロックサークルの右下の交点サークル
-            if direction == 0 or direction == 2:    # 向きが北 or 東
+
+        if sub == (1, 1):  # ブロックサークルの右下の交点サークル
+            if direction == 0 or direction == 2:  # 向きが北 or 東
                 # 走行体が北に向くように回頭コマンドの変換をする
-                direction = self.spin(src, (src[0]-1, src[1]), direction, has_block)
+                direction = self.spin(src, (src[0] - 1, src[1]), direction, has_block)
                 # 左方向にブロックを設置する
                 self.commands.append(Instructions.QUICK_PUT_L)
-            if direction == 4 or direction == 6:    # 向きが南 or 西
+            if direction == 4 or direction == 6:  # 向きが南 or 西
                 # 走行体が西に向くように回頭コマンドの変換をする
-                direction = self.spin(src, (src[0], src[1]-1), direction, has_block)
+                direction = self.spin(src, (src[0], src[1] - 1), direction, has_block)
                 # 右方向にブロックを設置する
                 self.commands.append(Instructions.QUICK_PUT_R)
-        
+
         return direction

--- a/source/block_bingo/test_block_bingo_solver.py
+++ b/source/block_bingo/test_block_bingo_solver.py
@@ -206,10 +206,9 @@ def test_solve_left():
         for y in range(0, 3+1):
             solver.cross_circles.set_block_color((x,y), block[x][y])
 
-    commands = ['e', 'u', 'd', 'u', 'u', 'y', 'u', 'u', 'd', 'u', 'u', 
-                'u', 'j', 'u', 'z', 'd', 'u', 'u', 'f', 'u', 'u', 'z',
-                'e', 'u', 'u', 'f', 'u', 'u', 'u', 'l', 'd', 'g', 'e',
-                'm', 'u', 'e', 'u', 'u', 'u', 'u', 'z',  'f', 'u', 'u', 'u', 'k', 'u', 'e']
+    commands = ['e', 'u', 'd', 'u', 'y', 'u', 'd', 'u', 'u', 'j', 'u', 'z', 'd', 'u', 'f', 'u', 'z',
+                'e', 'u', 'f', 'u', 'u', 'l', 'd', 'g', 'e',
+                'm', 'u', 'e', 'u', 'u', 'z',  'f', 'u', 'u', 'k', 'u', 'e']
 
     assert commands == solver.solve()
 
@@ -224,9 +223,8 @@ def test_solve_right():
         for y in range(0, 3+1):
             solver.cross_circles.set_block_color((x,y), block[x][y])
 
-    commands = ['e', 'm', 'u', 'f', 'u', 'm', 'h', 'd', 'g', 'd', 'u', 'u',
-                'u', 'z', 'e', 'u', 'u', 'f', 'u', 'k', 'u', 'z', 'e', 'u',
-                'u', 'u', 'u', 'd', 'y', 'u', 'k', 'u', 'u', 'k', 'u', 'u',
-                'u', 'z', 'u', 'j', 'u', 'e']
+    commands = ['e', 'm', 'u', 'f', 'u', 'm', 'h', 'd', 'g', 'd', 'u',
+                'u', 'z', 'e', 'u', 'f', 'u', 'k', 'u', 'z', 'e', 'u',
+                'u', 'd', 'y', 'u', 'k', 'u', 'k', 'u', 'u', 'z', 'u', 'j', 'u', 'e']
     
     assert commands == solver.solve()

--- a/source/block_bingo/test_commands.py
+++ b/source/block_bingo/test_commands.py
@@ -236,3 +236,12 @@ def test_convert():
     commands = create_commands()
     assert 0 == commands.convert(direction, path)
     assert result == commands.get()
+
+
+def test_get():
+    commands = create_commands()
+    commands.commands = ['u', 'u', 'k', 'u', 'u', 'u', 'u', 'u', 'u', 'e', 'a']
+
+    # uが2個連続するとき、1個にまとめられることを確認する
+    expected = ['u', 'k', 'u', 'u', 'u', 'e', 'a']
+    assert commands.get() == expected

--- a/source/block_bingo/test_commands.py
+++ b/source/block_bingo/test_commands.py
@@ -19,8 +19,8 @@ def test_translate():
     order = [instructions.translate(e) for e in order]
 
     assert order[0] == '6番サークルに進入'
-    assert order[1] == 'ブロックサークル間を直進'
-    assert order[2] == 'ブロックサークル間を直進'
+    assert order[1] == 'ブロックサークル間を移動'
+    assert order[2] == 'ブロックサークル間を移動'
     assert order[3] == '左に90°回頭する'
     assert order[4] == 'ブロックを黒線の中点から設置'
 


### PR DESCRIPTION
### このPRの目的(ISSUEあればURL)
- [走行体へ送信するコマンドを追加・修正する](https://github.com/KatLab-MiyazakiUniv/CameraSystem/issues/96)

### 何をしたか（変更点など）
- ブロックサークルから黒線の中点まで移動するPREPARE_TO_PUTコマンドを追加した
- ブロックサークル間後にPREPARE_TO_PUTを実行するようにコマンド変換を修正した
- 2回連続で交点サークル間の移動コマンドがある場合は、1つにまとめるように変更した
- 2回連続でブロックサークル間の移動コマンドがある場合は、1つにまとめるように変更した

### 使い方
- 何も使い方は変更していません。CameraSystemのmainを動かしてください

### テストする内容
- 正しく2回連続で交点サークル間の移動コマンドがある場合は、1つにまとめられることを確認する。

